### PR TITLE
Makefileでのコマンドエイリアス作成例

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+updev:
+	docker-compose up -d -f docker-compose.dev.yml
+down:
+	docker-compose down


### PR DESCRIPTION
# 概要

Makefileでコマンドエイリアスを作成する例です

# 使用法

リポジトリのrootで `make updev` とやるとMakefile内の通りコマンドが実行されます

# 備考

updevなどの引数はお好みで変えてもらって大丈夫ですー  
インデントはタブのみなので、このあたりはGNU MakeのMakefileの作り方を参照してみてください 👍